### PR TITLE
Match _T_ in log filenames

### DIFF
--- a/MCPU/sim/Starting_files_from_previous_simulation.sh
+++ b/MCPU/sim/Starting_files_from_previous_simulation.sh
@@ -11,7 +11,6 @@
 
 #Sample instance would be . ./Starting_files_from_previous_simulation.sh 1igd/MultiUmbrella 1igd/MultiUmbrella 99500000
 
-echo "WARNING: THIS IS GONNA GET CONFUSED BY ANY PROTEIN WHOSE DIRECTORY HAS A CAPITAL T IN IT, FOR INSTANCE CTS1...FIX THE CODE TO RECOGNIZE _T_ RATHER THAN JUST T"
 input_dir=$1
 output_dir=$2
 final_time=$3
@@ -20,13 +19,12 @@ array=( $( ls $input_dir/*.log ) )
 
 for logfile in "${array[@]}"
 do
-	IFS='T' read -r protein everything_else <<< "$logfile" 
-	IFS='_' read -r blank temp setpoint_log <<<"$everything_else"
+	IFS='|' read -r protein everything_else <<< "${logfile/_T_/|}" 
+	IFS='_' read -r temp setpoint_log <<<"$everything_else"
 	IFS='.' read -r setpoint log <<< "$setpoint_log"  
 	line=$(grep 'myrank' "$logfile")
 	IFS=' ' read -r blah colon myrank <<<"$line"
 	IFS=',' read -r myrank blah <<<"$myrank"
 	IFS='/' read -r blah blah protein <<<"$protein"
-	protein=${protein%?}  
 	cp $input_dir/${protein}_${temp}_$setpoint.$final_time $output_dir/$myrank.pdb
 done 


### PR DESCRIPTION
This fixes an issue where protein names with a capital T would break the script